### PR TITLE
erroneous packets crash bsb_telegram due to keyerror

### DIFF
--- a/bsbgateway/bsb/bsb_telegram.py
+++ b/bsbgateway/bsb/bsb_telegram.py
@@ -107,8 +107,10 @@ class BsbTelegram(object):
             data = [ord(c) for c in data]
         if data[0] != 0xdc:
             raise DecodeError("bad start marker")
-        if len(data) < 4 or len(data) < data[3]:
+        if len(data) < 5 or len(data) < data[3]:
             raise DecodeError("incomplete telegram")
+        if data[4] not in _PACKETTYPES:
+            raise DecodeError("Unknown or erroneous packet")
 
         tlen = data[3]
         if tlen < 11:


### PR DESCRIPTION
accepts unknown packets or packets with corrupted bits due to not following listen before talk

Only the case if...:
- messages are incoming with a type not registered in the PACKETTYPES list
- bit errors in serial data due to a device not following listen to talk or other interferences