### PR TITLE
correct web.py templates

### DIFF
--- a/bsbgateway/web_interface/field.html
+++ b/bsbgateway/web_interface/field.html
@@ -22,10 +22,10 @@ $code:
 
 
 
-<button onclick="$$('#fieldwidget-$field.disp_id').load('field-$(field.disp_id).widget');" value="Load">
+<button onclick="$$('#fieldwidget-$(field.disp_id)').load('field-$(field.disp_id).widget');" value="Load">
 <span class="fieldid">$field.disp_id</span>
 </button>
 <span class="fieldname">$field.disp_name</span>:
-<span class="fieldwidget" id="fieldwidget-$field.disp_id">
+<span class="fieldwidget" id="fieldwidget-$(field.disp_id)">
 </span>
-<span class="fieldsetresult" id="fieldsetresult-$field.disp_id"></span>
+<span class="fieldsetresult" id="fieldsetresult-$(field.disp_id)"></span>

--- a/bsbgateway/web_interface/field_dashwidget.html
+++ b/bsbgateway/web_interface/field_dashwidget.html
@@ -26,7 +26,7 @@ $code:
         <span class="fieldname">$field.disp_name</span>
     </p>
     <p>
-        <span class="fieldwidget" id="fieldwidget-$field.disp_id">
-        <span class="fieldsetresult" id="fieldsetresult-$field.disp_id"></span>
+        <span class="fieldwidget" id="fieldwidget-$(field.disp_id)">
+        <span class="fieldsetresult" id="fieldsetresult-$(field.disp_id)"></span>
     </p>
 </div>

--- a/bsbgateway/web_interface/field_widget.html
+++ b/bsbgateway/web_interface/field_widget.html
@@ -24,7 +24,7 @@ $code:
 $if not field.rw:
     <span class="fieldvalue">$SELF.fmt_rovalue(field, value)</span>
 $else:
-    <form class="fieldsetter" action="field-$field.disp_id" method="POST" onsubmit="return submit_field_$(field.type_name)(this);">
+    <form class="fieldsetter" action="field-$(field.disp_id)" method="POST" onsubmit="return submit_field_$(field.type_name)(this);">
         $if field.type_name == 'choice':
             <select name="value">
                 $if field.nullable:
@@ -33,7 +33,7 @@ $else:
                 $ keys = [key for key in field.choices.keys()]
                 $ keys.sort()
                 $for key in keys:
-                    <option value="$key" $('selected' if key==vkey else '')>$key $field.choices[key]</option>
+                    <option value="$(key)" $('selected' if key==vkey else '')>$key $field.choices[key]</option>
             </select>
             
         $elif field.type_name == 'time':
@@ -49,7 +49,7 @@ $else:
         $# Sending no value sets the NULL value.
         <form
             class="fieldsetter"
-            action="field-$field.disp_id"
+            action="field-$(field.disp_id)"
             method="POST"
             onsubmit="submit_field_null(this);return false;"
         >

--- a/bsbgateway/web_interface/group.html
+++ b/bsbgateway/web_interface/group.html
@@ -25,7 +25,7 @@ $code:
 
 <ul>
 $for f in group.fields:
-    <li class="fieldcontainer" id="fieldcontainer-$f.disp_id">
+    <li class="fieldcontainer" id="fieldcontainer-$(f.disp_id)">
         $:field_func(f)
     </li>
 </ul>

--- a/bsbgateway/web_interface/index.html
+++ b/bsbgateway/web_interface/index.html
@@ -37,6 +37,6 @@ $if fields:
 <h2>Parameter Groups</h2>
 <ul>
 $for group in groups:
-    <li><a href='group-$group.disp_id'>#$group.name</a></li>
+    <li><a href='group-$(group.disp_id)'>#$group.name</a></li>
 </ul>
 <script>$$(document).ready(load_all);</script>


### PR DESCRIPTION
Trying to use the html pages first time, I noticed error 500 returned from bsbgateway. 
I looked a bit into these and found that the template code cannot be parsed by web.py. Probably there were a few changes in web.py which broke the compatibility.

It was necessary to make variables in the templates more explicit by adding brackets around variables.
This PR fixes the errors and makes them usable again, at least for me (using python 3.12 on an ubuntu 24.04. system)